### PR TITLE
Simplify tooltip anchor logic and avoid pointer mismatches

### DIFF
--- a/app/src/components/charts/Axis.svelte
+++ b/app/src/components/charts/Axis.svelte
@@ -23,7 +23,7 @@
 		.map(d => ({value: format(d), offset: scale(d)}));
 </script>
 
-<g class='axis' {transform}>
+<g class='axis' {transform} pointer-events="none">
   {#each ticks as tick}
     {#if position === 'bottom'}
     <g class='tick' transform='translate({tick.offset}, 0)'>

--- a/app/src/components/charts/Axis.svelte
+++ b/app/src/components/charts/Axis.svelte
@@ -23,7 +23,7 @@
 		.map(d => ({value: format(d), offset: scale(d)}));
 </script>
 
-<g class='axis' {transform} pointer-events="none">
+<g class='axis' {transform} pointer-events='none'>
   {#each ticks as tick}
     {#if position === 'bottom'}
     <g class='tick' transform='translate({tick.offset}, 0)'>

--- a/app/src/components/charts/BarsWithBg.svelte
+++ b/app/src/components/charts/BarsWithBg.svelte
@@ -53,6 +53,17 @@
 		datum = undefined;
 	}
 
+	const getAnchor = (x) => {
+		switch(true) {
+			case x < 20:
+				return 'start';
+			case x  > width - 40:
+				return 'end';
+			default:
+				return 'middle'
+		}
+	}
+
 </script> 
 
 {#if width}
@@ -90,6 +101,7 @@
 			y1={y(0)}
 			x2={x(datum[key.x])}
 			y2={y(datum[key.y])}
+			pointer-events="none"
 			stroke="rgba(0,0,0,.5)"
 			stroke-width=.3
 			class="tooltip"
@@ -99,65 +111,28 @@
 			cx={x(datum[key.x])}
 			cy={y(datum[key.y])}
 			stroke="rgba(0,0,0,1)"
+			pointer-events="none"
 			stroke-width=2
 			class="tooltip blue"
 		/>
-		{#if x(datum[key.x]) < 20}
 		<text
 			x={x(datum[key.x])}
 			y={y(datum[key.y]) - 8}
-			text-anchor='start'
+			pointer-events="none"
+			text-anchor={getAnchor(x(datum[key.x]))}
 			class="tooltip value"
 		>
 			{format.y(datum[key.y])}
 		</text>
-		{:else if x(datum[key.x]) > width - 40}
-		<text
-			x={x(datum[key.x])}
-			y={y(datum[key.y]) - 8}
-			text-anchor='end'
-			class="tooltip value"
-		>
-			{format.y(datum[key.y])}
-		</text>
-		{:else}
-		<text
-			x={x(datum[key.x])}
-			y={y(datum[key.y]) - 8}
-			text-anchor='middle'
-			class="tooltip value"
-		>
-			{format.y(datum[key.y])}
-		</text>
-		{/if}
-		{#if x(datum[key.x]) < 20}
 		<text
 			x={x(datum[key.x])}
 			y={y(0) + 20}
-			text-anchor='start'
+			pointer-events="none"
+			text-anchor={getAnchor(x(datum[key.x]))}
 			class="tooltip date"
 		>
 			{format.x(datum[key.x])}
 		</text>
-		{:else if x(datum[key.x]) > width - 40}
-		<text
-			x={x(datum[key.x])}
-			y={y(0) + 20}
-			text-anchor='end'
-			class="tooltip date"
-		>
-			{format.x(datum[key.x])}
-		</text>
-		{:else}
-		<text
-			x={x(datum[key.x])}
-			y={y(0) + 20}
-			text-anchor='middle'
-			class="tooltip date"
-		>
-			{format.x(datum[key.x])}
-		</text>
-		{/if}
 		{/if}
 	</g>
 </svg>


### PR DESCRIPTION
This PR makes the tooltip anchor logic simpler and avoids problems with pointer events when hovering over the tooltip or axes (tested on Firefox and Safari).

## before
https://user-images.githubusercontent.com/1236790/106357413-3d0abe80-6306-11eb-9420-8bfd3a24f814.mov

## after
https://user-images.githubusercontent.com/1236790/106357421-4136dc00-6306-11eb-8a7f-54ee0b9d75e5.mov

